### PR TITLE
fix: 맛집, 메뉴, 한줄평이 길어질 경우의 문제 수정

### DIFF
--- a/BestEats.xcodeproj/project.pbxproj
+++ b/BestEats.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		E1492FA12C5B7D8E008EDC83 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1492FA02C5B7D8E008EDC83 /* SplashView.swift */; };
 		E1492FA42C5CBB7F008EDC83 /* TabItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1492FA32C5CBB7F008EDC83 /* TabItem.swift */; };
 		E1492FA62C6090C2008EDC83 /* UINavigationControllerEx.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1492FA52C6090C2008EDC83 /* UINavigationControllerEx.swift */; };
+		E1492FA82C609B47008EDC83 /* StringEx.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1492FA72C609B47008EDC83 /* StringEx.swift */; };
 		E1BAB8ED2C46653100873CA6 /* BestEatsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BAB8EC2C46653100873CA6 /* BestEatsApp.swift */; };
 		E1BAB8EF2C46653100873CA6 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BAB8EE2C46653100873CA6 /* TabBarView.swift */; };
 		E1BAB8F32C46653300873CA6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E1BAB8F22C46653300873CA6 /* Assets.xcassets */; };
@@ -96,6 +97,7 @@
 		E1492FA02C5B7D8E008EDC83 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		E1492FA32C5CBB7F008EDC83 /* TabItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabItem.swift; sourceTree = "<group>"; };
 		E1492FA52C6090C2008EDC83 /* UINavigationControllerEx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationControllerEx.swift; sourceTree = "<group>"; };
+		E1492FA72C609B47008EDC83 /* StringEx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringEx.swift; sourceTree = "<group>"; };
 		E1BAB8E92C46653100873CA6 /* BestEats.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BestEats.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1BAB8EC2C46653100873CA6 /* BestEatsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BestEatsApp.swift; sourceTree = "<group>"; };
 		E1BAB8EE2C46653100873CA6 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
@@ -176,6 +178,7 @@
 				E1DEE8BE2C490BD00035B56F /* ImageEx.swift */,
 				E1067C3E2C5A1749005FE587 /* ViewEx.swift */,
 				E1492FA52C6090C2008EDC83 /* UINavigationControllerEx.swift */,
+				E1492FA72C609B47008EDC83 /* StringEx.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -580,6 +583,7 @@
 				E148503C2C522CB8000A4272 /* Rate.swift in Sources */,
 				E1E1A28D2C4A2D5E00DDABF8 /* Restaurant+CoreDataClass.swift in Sources */,
 				E1E1A2742C49391D00DDABF8 /* RestaurantList.xcdatamodeld in Sources */,
+				E1492FA82C609B47008EDC83 /* StringEx.swift in Sources */,
 				E1E1A2942C4A360300DDABF8 /* AddButton.swift in Sources */,
 				E1067C302C58C3E8005FE587 /* BackButton.swift in Sources */,
 				E1E1A27E2C493D2000DDABF8 /* CoreDataManager.swift in Sources */,

--- a/BestEats/Util/Extensions/StringEx.swift
+++ b/BestEats/Util/Extensions/StringEx.swift
@@ -1,0 +1,12 @@
+//
+//  StringEx.swift
+//  BestEats
+//
+//  Created by BH on 2024/08/05.
+//
+
+extension String {
+    func trimming() -> String {
+        return self.trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/BestEats/View/Menu/AddMenuSheet.swift
+++ b/BestEats/View/Menu/AddMenuSheet.swift
@@ -22,7 +22,11 @@ struct AddMenuSheet: View {
     
     var restaurant: Restaurant
     
-    private var isValid: Bool { !menuName.isEmpty && !oneLiner.isEmpty }
+    private var isValid: Bool {
+        !menuName.trimming().isEmpty &&
+        !oneLiner.trimming().isEmpty &&
+        oneLiner.trimming().count <= 30
+    }
     
     var body: some View {
         VStack {
@@ -38,7 +42,7 @@ struct AddMenuSheet: View {
                 .font(.pretendardMedium16)
                 Text("한줄평")
                 TextField(
-                    "한줄평을 입력해주세요",
+                    "한줄평을 입력해주세요 (30자 이내)",
                     text: $oneLiner
                 )
                 .textFieldStyle(.roundedBorder)
@@ -93,12 +97,18 @@ struct AddMenuSheet: View {
     }
     
     private func addMenu(isFavorite: Bool) {
+        let menuName = self.menuName.trimming()
+        let oneLiner = self.oneLiner.trimming()
+        
         coreDataManager.addMenu(with: restaurant, menuName, oneLiner, rateType, isFavorite)
         dismiss()
     }
     
     private func showFillOutToast() {
-        self.toastText = menuName.isEmpty ? "메뉴명을 입력해주세요" : "한줄평을 입력해주세요"
+        self.toastText = menuName.trimming().isEmpty
+        ? "메뉴명을 입력해주세요"
+        : "한줄평을 입력해주세요 (30자 이내)"
+        
         toastManager.showToast(message: self.toastText)
     }
 }

--- a/BestEats/View/Menu/MenuDetailView.swift
+++ b/BestEats/View/Menu/MenuDetailView.swift
@@ -51,7 +51,7 @@ struct MenuDetailView: View {
                 .font(.pretendardMedium16)
                 Text("한줄평")
                 TextField(
-                    "한줄평을 입력해주세요",
+                    "한줄평을 입력해주세요 (30자 이내)",
                     text: $oneLiner
                 )
                 .disabled(!isEditMode)
@@ -98,7 +98,7 @@ struct MenuDetailView: View {
     
     
     private func checkValid() {
-        if name.isEmpty || oneLiner.isEmpty {
+        if name.trimming().isEmpty || oneLiner.trimming().isEmpty {
             showFillOutToast()
         } else {
             handleSaveAction()
@@ -106,13 +106,16 @@ struct MenuDetailView: View {
     }
     
     private func showFillOutToast() {
-        self.toastText = name.isEmpty ? "메뉴명을 입력해주세요" : "한줄평을 입력해주세요"
+        self.toastText = name.trimming().isEmpty
+        ? "메뉴명을 입력해주세요"
+        : "한줄평을 입력해주세요 (30자 이내)"
+        
         toastManager.showToast(message: toastText)
     }
     
     private func handleSaveAction() {
         rateType == .like
-        ? self.showFavoriteAlert = true
+        ? showFavoriteAlert = true
         : handleSave(isFavorite: false)
     }
     
@@ -121,6 +124,9 @@ struct MenuDetailView: View {
     }
     
     private func handleSave(isFavorite: Bool) {
+        let name = self.name.trimming()
+        let oneLiner = self.oneLiner.trimming()
+        
         coreDataManager.updateMenu(
             with: restaurant,
             id: menu?.id ?? UUID(),

--- a/BestEats/View/Menu/MenuItemView.swift
+++ b/BestEats/View/Menu/MenuItemView.swift
@@ -20,6 +20,7 @@ struct MenuItemView: View {
                 Text(menu.wrappedName)
                     .font(.pretendardBold20)
                     .foregroundStyle(.orange)
+                    .lineLimit(1)
                 
                 Spacer()
                 
@@ -47,6 +48,7 @@ struct MenuItemView: View {
             VStack {
                 Text(menu.wrappedOneLiner)
                     .font(.pretendardSemiBold16)
+                    .lineLimit(2)
             }
         }
         .padding(.top)

--- a/BestEats/View/Restaurant/AddRestaurantSheet.swift
+++ b/BestEats/View/Restaurant/AddRestaurantSheet.swift
@@ -20,7 +20,12 @@ struct AddRestaurantSheet: View {
     @State var toastText: String = ""
     @State var showFavoriteAlert: Bool = false
     
-    private var isValid: Bool { !restaurantName.isEmpty && !menuName.isEmpty && !oneLiner.isEmpty }
+    private var isValid: Bool {
+        !restaurantName.trimming().isEmpty &&
+        !menuName.trimming().isEmpty &&
+        !oneLiner.trimming().isEmpty &&
+        oneLiner.trimming().count <= 30
+    }
     
     var body: some View {
         VStack {
@@ -43,7 +48,7 @@ struct AddRestaurantSheet: View {
                 .font(.pretendardMedium16)
                 Text("한줄평")
                 TextField(
-                    "한줄평을 입력해주세요",
+                    "한줄평을 입력해주세요 (30자 이내)",
                     text: $oneLiner
                 )
                 .textFieldStyle(.roundedBorder)
@@ -87,6 +92,7 @@ struct AddRestaurantSheet: View {
         }
         .padding(.horizontal, 24)
         .padding(.top, 24)
+        .toast(toastManager: toastManager)
         .favoriteAlert(isPresented: $showFavoriteAlert) { isFavorite in
             addRestaurant(isFavorite: isFavorite)
         }
@@ -101,6 +107,10 @@ struct AddRestaurantSheet: View {
     }
     
     private func addRestaurant(isFavorite: Bool) {
+        let restaurantName = self.restaurantName.trimming()
+        let menuName = self.menuName.trimming()
+        let oneLiner = self.oneLiner.trimming()
+        
         coreDataManager.addRestaurant(restaurantName, menuName, oneLiner, rateType, isFavorite)
         dismiss()
     }
@@ -108,12 +118,12 @@ struct AddRestaurantSheet: View {
     private func checkEmptyForm() {
         var toastText: String = ""
         
-        if restaurantName.isEmpty {
+        if restaurantName.trimming().isEmpty {
             toastText = "맛집명을 입력해주세요"
-        } else if menuName.isEmpty {
+        } else if menuName.trimming().isEmpty {
             toastText = "메뉴명을 입력해주세요"
         } else {
-            toastText = "한줄평을 입력해주세요"
+            toastText = "한줄평을 입력해주세요 (30자 이내)"
         }
         
         showFillOutToast(message: toastText)

--- a/BestEats/View/Restaurant/RestaurantCardView.swift
+++ b/BestEats/View/Restaurant/RestaurantCardView.swift
@@ -29,6 +29,7 @@ struct RestaurantCardView: View {
                     Text(restaurant.wrappedName)
                         .font(.pretendardBold24)
                         .foregroundStyle(.orange)
+                        .lineLimit(1)
                     
                     Spacer()
                     
@@ -38,45 +39,12 @@ struct RestaurantCardView: View {
                         Image(systemName: "ellipsis")
                             .foregroundStyle(.black)
                     })
-                    .confirmationDialog(
-                        "맛집 설정",
-                        isPresented: $showDialog,
-                        titleVisibility: .visible,
-                        actions: {
-                            Button("변경") {
-                                self.showEditAlert.toggle()
-                            }
-                        
-                            Button(role: .destructive) {
-                                self.showDeleteAlert.toggle()
-                            } label: {
-                                Text("삭제")
-                            }
-                            Button("취소", role: .cancel) {}
-                        }, message: {
-                            Text("아래 항목을 선택해주세요")
-                        })
-                }
-                // 수정 Alert
-                .alert("맛집이름 변경", isPresented: $showEditAlert) {
-                    TextField("맛집이름", text: $newName)
-                    Button("취소", role: .cancel) {}
-                    Button("변경") { updateRestaurant(with: newName) }
-                } message: {
-                    Text("맛집이름을 변경해주세요")
-                }
-                
-                // 삭제 Alert
-                .alert("맛집 삭제", isPresented: $showDeleteAlert) {
-                    Button("취소", role: .cancel) {}
-                    Button("삭제", role: .destructive) { deleteRestaurant() }
-                } message: {
-                    Text("맛집에 포함된 메뉴들도 삭제 됩니다\n 삭제하시겠습니까?")
                 }
                 
                 Spacer()
                 
                 favoriteMenuText(with: restaurant)
+                    .lineLimit(1)
                 
                 Spacer()
                 
@@ -103,6 +71,41 @@ struct RestaurantCardView: View {
         .padding(24)
         .background(.background)
         .clipShape(RoundedRectangle(cornerRadius: 16.0))
+        .confirmationDialog(
+            "맛집 설정",
+            isPresented: $showDialog,
+            titleVisibility: .visible,
+            actions: {
+                Button("변경") {
+                    self.showEditAlert.toggle()
+                }
+            
+                Button(role: .destructive) {
+                    self.showDeleteAlert.toggle()
+                } label: {
+                    Text("삭제")
+                }
+                Button("취소", role: .cancel) {}
+            }, message: {
+                Text("아래 항목을 선택해주세요")
+            })
+        
+        // 수정 Alert
+        .alert("맛집이름 변경", isPresented: $showEditAlert) {
+            TextField("맛집이름", text: $newName)
+            Button("취소", role: .cancel) {}
+            Button("변경") { updateRestaurant(with: newName) }
+        } message: {
+            Text("맛집이름을 변경해주세요")
+        }
+        
+        // 삭제 Alert
+        .alert("맛집 삭제", isPresented: $showDeleteAlert) {
+            Button("취소", role: .cancel) {}
+            Button("삭제", role: .destructive) { deleteRestaurant() }
+        } message: {
+            Text("맛집에 포함된 메뉴들도 삭제 됩니다\n 삭제하시겠습니까?")
+        }
     }
     
     private func favoriteMenuText(with restaurant: Restaurant) -> Text {


### PR DESCRIPTION
## 1. 개요
<!-- 이슈에 대한 내용을 작성해주세요.  -->
- 메뉴, 맛집, 한줄평이 길어질 경우 글자수를 자르는 기능이 필요
- 한줄평의 글자 수 30자로 제한

<br>

## 2. 참고사항
<!-- 참고할 링크가 있다면 첨부해주세요.  -->
- 노션 or 피그마: 링크

<br>

## 3. 재현방법
<!-- 필요한 구현 사항을 TODO로 작성해주세요  -->

1. 맛집명, 메뉴명, 한줄평의 길이가 너무 길 경우
2. 칸이 늘어나게 되는 문제

## 4. 해결
- 맛집, 메뉴, 한줄평 맨앞 공백있을시 제거하고 문자 추가 (trimming)
- 맛집, 메뉴명 한줄만 표기
- 한줄평 두줄까지 표기 및 30자 제한
- 맛집 추가시 토스트 안뜨는 문제 수정